### PR TITLE
Initial stab at release process document

### DIFF
--- a/development/release/index.rst
+++ b/development/release/index.rst
@@ -1,19 +1,22 @@
-
-: ..releasing:
+.. _releasing:
 
 Release Process
 ================
 
-TODO: Document basic release process. 
-
-Release steps might include:
-- Release milestone created in github for appropriate repositories
-- Team identifies target features for release and assign milestone to associated issues
-- Features are completed and tested
-- Publish release candidate(s)
-- Test release candidate(s)
-- Publish final release
-- Release notes created
-- Install release to production instance
-- Announce release
-
+Release process includes the following:
+* Create release milestones in Github for the following repositories
+ - `dashboard <https://github.com/whole-tale/dashboard>`_
+ - `terraform_deployment <https://github.com/whole-tale/terraform_deployment>`_
+ - `wt-design-docs <https://github.com/whole-tale/wt-design-docs>`_
+ - `wt_home_dirs <https://github.com/whole-tale/wt_home_dirs>`_
+ - `girder_wholetale <https://github.com/whole-tale/girder_wholetale>`_
+* Team identifies target features for release, creates issues, and assigns milestones to associated issues
+* Features are implemented, tested, and documentation updated either on ``master`` or a designated feature branch
+* Changes are merged to ``stable`` branch
+* Stable branch is updated with any version changes, if applicable
+* Release candidate is created by tagging the ``stable`` branch (v1.0-rc1)
+* Release candidate is tested
+* Release notes are created and added to documentation
+* Final release is created by tagging the ``stable`` branch  (v1.0)
+* Install release to production instance
+* Announce release to community


### PR DESCRIPTION
Trying to document the release process at a high level. Eventually we might get into more detail for a step-by-step that can eventually be automated. NDS has a painful process now (https://opensource.ncsa.illinois.edu/confluence/display/NDS/Developer+Workflows#DeveloperWorkflows-OfficialTaggedVersionRelease(Stable))