### PR TITLE
have Dataverse pass dataset DOI (Persistent ID) #95

### DIFF
--- a/users_guide/wholetale.json
+++ b/users_guide/wholetale.json
@@ -7,7 +7,7 @@
   "toolParameters": {
     "queryParameters": [
       {
-        "fileId": "{fileId}"
+        "datasetPid": "{datasetPid}"
       },
       {
         "siteUrl": "{siteUrl}"


### PR DESCRIPTION
Also avoids this error when loading the manifest into Dataverse:

"One of the following reserved words is required: {datasetId}, {datasetPid}."