### PR TITLE
Clarified data location during /tale/import cases

### DIFF
--- a/ISSUE_TEMPLATE/test_plan.md
+++ b/ISSUE_TEMPLATE/test_plan.md
@@ -312,7 +312,7 @@ Testing Steps:
    8. Click ``Create New Tale and Launch``
    10. Confirm that you are redirected to the run page
    11. Confirm that the Tale name matches the Tale Name in the Create Tale Modal
-   12. Confirm that the data exists in the Tale
+   12. Confirm that the data exists in the Tale Workspace and **not** under External Data
 
 #### Task 2: Importing a Dataset from DataONE
 
@@ -333,7 +333,7 @@ Testing Steps:
    7. Click ``Create New Tale and Launch``
    9. Confirm that you are redirected to the run page
    10. Confirm that the Tale name matches the Tale Name in the Create Tale Modal
-   11. Confirm that the data exists in the Tale
+   11. Confirm that the data exists in the Tale under External Data
 
 #### Task 3: Shared Behavior
 
@@ -370,7 +370,7 @@ Testing Steps:
    9. Confirm that the notification bar appears & properly updates
    10. Confirm that you are redirected to the run page
    11. Confirm that the Tale name matches the Tale Name in the Create Tale Modal
-   12. Confirm that the data exists in the Tale
+   12. Confirm that the data exists in the Tale under External Data
 
 ### Tale metadata tests
 The purpose of these tests are to confirm that the metadata files (manifest.json, environment.json, LICENSE) we generate are correct.


### PR DESCRIPTION
## Problem
The test cases for `POST /tale/import` are missing some details from the verification step(s). The missing information nearly caused us to miss a very subtle bug during the v0.8 release.

## Approach
Update the test case to include verification steps that clarify where the user should be able to find the data (e.g. "under External Data" or "in the Tale Workspace").

## See Also
https://github.com/whole-tale/dashboard/pull/548