### PR TITLE
Update allowed operations in workspace

### DIFF
--- a/ISSUE_TEMPLATE/test_plan.md
+++ b/ISSUE_TEMPLATE/test_plan.md
@@ -241,7 +241,6 @@ Preconditions:
    1. Confirm context menu Move To, Copy, Rename, Download, Remove
       * Note: "Move To" is missing as of v0.8
    1. Confirm rename folder
-   1. Copy to Home confirm folder copied to home
    1. Confirm download -- zip file 
    1. Confirm remove
 1. File operations

--- a/ISSUE_TEMPLATE/test_plan.md
+++ b/ISSUE_TEMPLATE/test_plan.md
@@ -240,7 +240,7 @@ Preconditions:
    1. Confirm context menu Move To, Copy, Rename, Download, Remove
       * Note: "Move To" is missing as of v0.8
    1. Confirm rename folder
-   1. Confirm download -- zip file 
+    1. Confirm download folder (this should result in a zip file) 
    1. Confirm remove
 1. File operations
    1. Upload a file

--- a/ISSUE_TEMPLATE/test_plan.md
+++ b/ISSUE_TEMPLATE/test_plan.md
@@ -240,7 +240,7 @@ Preconditions:
       * Note: "Move To" is missing as of v0.8
    1. Confirm rename folder
     1. Confirm download folder (this should result in a zip file) 
-   1. Confirm remove
+    1. Confirm remove folder
 1. File operations
    1. Upload a file
    1. Confirm context menu Move To, Copy, Rename, Download, Remove

--- a/ISSUE_TEMPLATE/test_plan.md
+++ b/ISSUE_TEMPLATE/test_plan.md
@@ -247,7 +247,7 @@ Preconditions:
       * Note: "Move To" is missing as of v0.8
    1. Confirm rename folder
    1. Confirm download 
-   1. Confirm remove
+    1. Confirm remove file
 1. Select "Import Tale Data..."
    1. Note vertical navigation with Tale Workspaces
    1. Copy to Workspace from another workspace 

--- a/ISSUE_TEMPLATE/test_plan.md
+++ b/ISSUE_TEMPLATE/test_plan.md
@@ -234,7 +234,6 @@ Preconditions:
 * [ ] Workspaces
 1. Confirm create folder
 1. Confirm upload file
-1. Confirm remove file/folder
 1. Select "+" button has options "New folder", "Upload file", Import Tale Data..."
 1. Folder operations
    1. Confirm context menu Move To, Copy, Rename, Download, Remove

--- a/ISSUE_TEMPLATE/test_plan.md
+++ b/ISSUE_TEMPLATE/test_plan.md
@@ -233,7 +233,6 @@ Preconditions:
 
 * [ ] Workspaces
 1. Confirm create folder
-1. Confirm rename folder/file
 1. Confirm upload file
 1. Confirm remove file/folder
 1. Select "+" button has options "New folder", "Upload file", Import Tale Data..."

--- a/ISSUE_TEMPLATE/test_plan.md
+++ b/ISSUE_TEMPLATE/test_plan.md
@@ -246,7 +246,7 @@ Preconditions:
    1. Confirm context menu Move To, Copy, Rename, Download, Remove
       * Note: "Move To" is missing as of v0.8
    1. Confirm rename folder
-   1. Confirm download 
+    1. Confirm download file
     1. Confirm remove file
 1. Select "Import Tale Data..."
    1. Note vertical navigation with Tale Workspaces

--- a/ISSUE_TEMPLATE/test_plan.md
+++ b/ISSUE_TEMPLATE/test_plan.md
@@ -235,31 +235,24 @@ Preconditions:
 1. Confirm create folder
 1. Confirm rename folder/file
 1. Confirm upload file
-1. Confirm copy file/folder from/to Home
-1. Confirm move file/folder from/to Home
 1. Confirm remove file/folder
 1. Select "+" button has options "New folder", "Upload file", Import Tale Data..."
 1. Folder operations
-   1. Confirm context menu Move To, Rename, Copy to Home, Download, Remove
-   1. Move To... 
-      1. Issue -- should this be enabled 
+   1. Confirm context menu Move To, Copy, Rename, Download, Remove
+      * Note: "Move To" is missing as of v0.8
    1. Confirm rename folder
    1. Copy to Home confirm folder copied to home
    1. Confirm download -- zip file 
    1. Confirm remove
 1. File operations
    1. Upload a file
-   1. Confirm context menu Move To, Rename, Copy to Home, Download, Remove
-   1. Move To... Home?
-      1. Issue -- doesn't work
+   1. Confirm context menu Move To, Copy, Rename, Download, Remove
+      * Note: "Move To" is missing as of v0.8
    1. Confirm rename folder
-   1. Copy to Home confirm folder copied to home
    1. Confirm download 
    1. Confirm remove
-1. Select "Select Data..."
-   1. Note vertical navigation with Home and Tale Workspaces
-   1. Copy to Workspace from Home 
-   1. Move to Workspace from Home
+1. Select "Import Tale Data..."
+   1. Note vertical navigation with Tale Workspaces
    1. Copy to Workspace from another workspace 
    1. Move to workspace from another workspace
 


### PR DESCRIPTION
As per Mike's [comment](https://github.com/whole-tale/dashboard/pull/556#issuecomment-542779226) I'm updating test plan to reflect actual and desired behavior of file/folder ops in workspace.

Note that `move to` doesn't exists, but I don't think it should block v0.8,