### PR TITLE
Remove assumption of root terminal access

### DIFF
--- a/ISSUE_TEMPLATE/test_plan.md
+++ b/ISSUE_TEMPLATE/test_plan.md
@@ -292,12 +292,8 @@ Preconditions:
   [#370](https://github.com/whole-tale/girder_wholetale/pull/370)
 1. Connect one or more accounts as outlined above
 1. Logout and login again
-1. Using `girder-shell`, confirm tokens are still present
-```
-$ docker exec -ti $(docker ps --filter=name=wt_girder -q) girder-shell
-from girder.models.user import User
-User().findOne({"user": False})["otherTokens"]
-```
+1. Using Swagger UI, hit the `/user/me` endpoint to confirm tokens are still present
+
 
 ### Tale Creation
 


### PR DESCRIPTION
## Problem
We can't guarantee that testers will have root terminal access to the machine on which WT is running.

## Approach
There is only one test case that assumes such - adjust it to use Swagger UI to hit the endpoint, instead of querying Girder/Mongo directly.