### PR TITLE
v0.9rc3 test plan improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/TEST_PLAN.md
+++ b/.github/ISSUE_TEMPLATE/TEST_PLAN.md
@@ -9,7 +9,7 @@ assignees: ''
 
 # Test Plan
 
-https://github.com/whole-tale/wt-design-docs/issues/new?template=test_plan.md
+https://github.com/whole-tale/wt-design-docs/issues/new?template=TEST_PLAN.md
 
 Note: For all tests, repeat for supported browser/OS combinations.
 
@@ -88,7 +88,7 @@ Preconditions:
 1. Confirm that your Tales are shown under "My Tales"
 1. Select "My Tales"
 1. View a Tale and then navigate back to Browse
-1. Confirm the filter is reset
+1. Confirm the filter is not reset
 
 
 * [ ] View tale
@@ -379,8 +379,8 @@ The `Analyze in Whole Tale` feature is deployed across a few DataONE test sites.
 data from each of them.
 
 Links:
-  1. https://dashboard.stage.wholetale.org/browse?api=https%3A%2F%2Fdev.nceas.ucsb.edu%2Fknb%2Fd1%2Fmn%2Fv2&name=Dataone Dataset&uri=https://dev.nceas.ucsb.edu/view/doi:10.5072/FK2K075M25
-  1. https://dashboard.stage.wholetale.org/browse?api=https://test.arcticdata.io/metacat/d1/mn/v2&name=Dataone Dataset&uri=https://test.arcticdata.io/view/doi:10.5065/D6N014NC
+  1. https://dashboard.stage.wholetale.org/browse?api=https%3A%2F%2Fdev.nceas.ucsb.edu%2Fknb%2Fd1%2Fmn%2Fv2&name=Dataone%20Dataset&uri=https://dev.nceas.ucsb.edu/view/doi:10.5072/FK2K075M25
+  1. https://dashboard.stage.wholetale.org/browse?api=https://test.arcticdata.io/metacat/d1/mn/v2&name=Dataone%20Dataset&uri=https://test.arcticdata.io/view/doi:10.5065/D6N014NC
 
 Testing Steps:
    1. Remove all running Tale instances


### PR DESCRIPTION
* Filter on `tale-browser` no longer resets on navigation
* Removed spaces from DataONE test URLs