### PR TITLE
Added terms of use

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -20,6 +20,7 @@ Overview
    :caption: Platform Information:
 
    users_guide/index
+   tos/index
    architecture/index
    admin_guide/index
    release/index

--- a/tos/index.rst
+++ b/tos/index.rst
@@ -1,0 +1,14 @@
+.. image:: http://readthedocs.org/projects/wholetale/badge/?version=latest
+   :target: http://wholetale.readthedocs.io/en/latest/?badge=latest
+
+Terms of Use
+=============
+
+Whole Tale on Jetstream is for academic use only and limited to fair and 
+reasonable use. 
+
+MATLAB licensing is on a "right to use" basis and not guaranteed in perpetuity.
+Absolutely no proprietary, closed, or for-profit use of MATLAB is permitted.
+
+Violating any terms of service with respect to XSEDE, Jetstream, or Mathworks
+licensing may result in loss of access to these services.


### PR DESCRIPTION
Per https://github.com/whole-tale/whole-tale/issues/85, we need to add terms of service/use to be in compliance with Jetstream policy as well as Mathworks licensing.

This PR adds a basic TOS page to the help documentation based on language provided by Jetstream support.