### PR TITLE
Drop references to D1 publishing

### DIFF
--- a/.github/ISSUE_TEMPLATE/TEST_PLAN.md
+++ b/.github/ISSUE_TEMPLATE/TEST_PLAN.md
@@ -694,33 +694,6 @@ users. To run these tests, register at least one other account, referred to as U
   1. Click `Go to Settings`
   1. Confirm you are re-directed to settings
 
-* [ ] Case 2: Publishing to DataONE
-  1. Connect to DataONE (dev server)
-  1. Open a Tale that you own
-  1. Add some data to it
-  1. Click `Publish tale...`
-  1. Confirm that the publishing modal opens
-  1. Confirm that the third party that you are connected to appears in the dropdown
-  1. Select the third party
-  1. Click `Publish`
-  1. Once complete, navigate to the metadata page
-  1. Confirm that the published location is present
-  1. Visit the published location
-  1. Confirm that you see the following files plus yours
-      1. `metadata.xml`
-      1. `LICENSE`
-      1. `README.md`
-      1. `manifest.json`
-      1. `environment.json`
-  1. After publishing to DataONE, use girder to query the Tale
-  1. Ensure that the 'pid' field in the 'publishInfo' object has an identifier in a doi format
-
-* [ ] Case 3: Re-publish Tale to DataONE
-1. Launch a Tale that has been published before
-1. Take note of the `Published Location` in Run > metadata
-1. Re-publish the Tale to the third party
-1. Confirm that the `Published Location` has changed to the correct package landing page
-
 ## Zenodo integration tests
 
 * [ ] Register Zenodo data

--- a/users_guide/publishing.rst
+++ b/users_guide/publishing.rst
@@ -18,14 +18,6 @@ data submissions, which is supported in Whole Tale's system.
    Before publishing to production servers, it's recommended to first publish to
    the Zenodo sandbox repository.
 
-DataONE
-^^^^^^^
-DataONE is a network of data centers and organizations that share their information 
-across a network of nodes, where data is replicated and described with rich metadata.
-Publishing your tale into the DataONE network will allow you to archive your work, 
-collect usage statistics, and make it easy to share with other scientists.
-
-
 Publishing Your Tale
 --------------------
 

--- a/users_guide/scenarios.rst
+++ b/users_guide/scenarios.rst
@@ -21,4 +21,4 @@ A user follows the introductory tutorial to learn how to create a Tale in the Wh
 
 Publishing a Tale
 -----------------
-A scientist did research within Whole Tale and wants to publish their results with a DOI. Once their analysis is complete, any additional Tale metadata should be entered in the metadata tab on the Run page. When ready to publish, the researcher can select `Publish` from the three-dot dropdown menu on the Run page. Once signed into DataONE, the researcher can choose which repository they wish to publish to. Once published, they can view the location of their package on the metadata page.
+A scientist did research within Whole Tale and wants to publish their results with a DOI. Once their analysis is complete, any additional Tale metadata should be entered in the metadata tab on the Run page. When ready to publish, the researcher can select `Publish` from the three-dot dropdown menu on the Run page. Once authenticated with Zenodo, the researcher can choose which repository they wish to publish to. Once published, they can view the location of their package on the metadata page.

--- a/users_guide/settings.rst
+++ b/users_guide/settings.rst
@@ -5,16 +5,6 @@ Account Settings
 The Account Settings page allows you to manage your third party integrations. From here you can check which 
 services Whole Tale has access to and manage your API keys.
 
-Connecting to DataONE
----------------------
-Connecting to DataONE requires that you have an ORCID or university account. When connecting your Whole Tale account with DataONE, you'll be asked to log into either one. 
-Whole Tale will automatically request your API token from DataONE once connected.
-
-Whole Tale allows you to connect to the following DataONE instances.
-
-1. `DataONE <https://dataone.org/>`_
-2. `Dataone Development <https://dev.nceas.ucsb.edu>`_
-
 Connecting to Dataverse
 -----------------------
 You can connect your Whole Tale account with Dataverse by providing your Dataverse API key. A guide on obtaining your API key 


### PR DESCRIPTION
As a consequence of https://github.com/whole-tale/gwvolman/pull/194 I'm dropping all mentions of publish to DataONE.