### PR TITLE
environment.yaml -> environment.yml for consistency

### DIFF
--- a/users_guide/customizing.rst
+++ b/users_guide/customizing.rst
@@ -116,7 +116,7 @@ Python
 ------
 
 Python packages can be specified using :code:`requirements.txt`, :code:`Pipfile`/:code:`Pipfile.lock`, or 
-Conda :code:`environment.yaml`.
+Conda :code:`environment.yml`.
 
 Example :code:`requirements.txt`: 
 


### PR DESCRIPTION
I'm not completely sure this matters but the conda convention and as documented on repo2docker is environment.yml. probably best to be consistent regardless